### PR TITLE
Automate publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,33 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: npm
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm install
+      - run: npm test
+
+  Publish:
+    needs: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,33 +1,33 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+# Collaborators can publish a new version **of what's on master** by leaving a review on any PR, generally the PR that just closed.
+# To trigger this, the comment must match the format `🚀 version`, where "version" is anything accepted by `npm version XXX`
 
-name: npm
+name: Publish
 
 on:
-  release:
-    types: [created]
+  pull_request_review:
+    types:
+      - submitted
 
 jobs:
-  Build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
-      - run: npm install
-      - run: npm test
 
-  Publish:
-    needs: Build
+  npm:
     runs-on: ubuntu-latest
+    if: contains('OWNER,COLLABORATOR', github.event.review.author_association) && startsWith(github.event.review.body, '🚀')
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
         with:
-          node-version: 12
-          registry-url: https://registry.npmjs.org/
-      - run: npm ci
+          ref: master
+      - run: npm install
+      - uses: fregante/setup-git-token@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: npm version
+        run: |
+          WORDS=($COMMENT)
+          npm version ${WORDS[1]}
+        env:
+          COMMENT: ${{ github.event.review.body }}
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+      - run: git push --follow-tags


### PR DESCRIPTION
I thought that using GitHub’s suggested workflow would be enough to automate publishing, but it's incomplete.

Creating a Release online is not enough, I'd still have to run `npm version a.b.c && git push --follow-tags`, which defeats the purpose of this workflow.

However perhaps this can be built on somehow.