### PR TITLE
Use canonical URL in `utils.getRepoURL`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -456,7 +456,7 @@ const getRepoPath = (url: URL | Location = location): string | undefined => {
 };
 
 /** Get the 'user/repo' part from an URL. Tries using the canonical URL to avoid capitalization errors in the `location` URL */
-const getRepoURL = (url: URL | Location): string => {
+const getRepoURL = (url?: URL | Location): string => {
 	if (!url) {
 		const canonical = document.querySelector<HTMLMetaElement>('[property="og:url"]'); // `rel=canonical` doesn't appear on every page
 		if (canonical) {
@@ -466,7 +466,7 @@ const getRepoURL = (url: URL | Location): string => {
 		}
 	}
 
-	return url.pathname.slice(1).split('/', 2).join('/')
+	return url.pathname.slice(1).split('/', 2).join('/');
 };
 
 export const utils = {

--- a/index.ts
+++ b/index.ts
@@ -459,11 +459,7 @@ const getRepoPath = (url: URL | Location = location): string | undefined => {
 const getRepoURL = (url?: URL | Location): string => {
 	if (!url) {
 		const canonical = document.querySelector<HTMLMetaElement>('[property="og:url"]'); // `rel=canonical` doesn't appear on every page
-		if (canonical) {
-			url = new URL(canonical.content);
-		} else {
-			url = location;
-		}
+		url = canonical ? new URL(canonical.content) : location;
 	}
 
 	return url.pathname.slice(1).split('/', 2).join('/');

--- a/index.ts
+++ b/index.ts
@@ -456,7 +456,18 @@ const getRepoPath = (url: URL | Location = location): string | undefined => {
 };
 
 /** Get the 'user/repo' part from an URL. Tries using the canonical URL to avoid capitalization errors in the `location` URL */
-const getRepoURL = (url: URL | Location = new URL(document.querySelector('[property="og:url"]')?.content ?? location.href)): string => url.pathname.slice(1).split('/', 2).join('/');
+const getRepoURL = (url: URL | Location): string => {
+	if (!url) {
+		const canonical = document.querySelector<HTMLMetaElement>('[property="og:url"]'); // `rel=canonical` doesn't appear on every page
+		if (canonical) {
+			url = new URL(canonical.content);
+		} else {
+			url = location;
+		}
+	}
+
+	return url.pathname.slice(1).split('/', 2).join('/')
+};
 
 export const utils = {
 	getUsername,

--- a/index.ts
+++ b/index.ts
@@ -455,8 +455,8 @@ const getRepoPath = (url: URL | Location = location): string | undefined => {
 	return undefined;
 };
 
-/** Get the 'user/repo' part from an URL */
-const getRepoURL = (url: URL | Location = location): string => url.pathname.slice(1).split('/', 2).join('/');
+/** Get the 'user/repo' part from an URL. Tries using the canonical URL to avoid capitalization errors in the `location` URL */
+const getRepoURL = (url: URL | Location = new URL(document.querySelector('[property="og:url"]')?.content ?? location.href)): string => url.pathname.slice(1).split('/', 2).join('/');
 
 export const utils = {
 	getUsername,


### PR DESCRIPTION
This should improve support of `aNyCaSe/RePos` across the board