### PR TITLE
Include `isSingleGist` in `hasRichTextEditor`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -440,7 +440,8 @@ export const hasRichTextEditor = (url: URL | HTMLAnchorElement | Location = loca
 	hasComments(url) ||
 	isNewIssue(url) ||
 	isCompare(url) ||
-	isRepliesSettings(url);
+	isRepliesSettings(url) ||
+	isSingleGist(url);
 
 collect.set('hasCode', combinedTestOnly);
 export const hasCode = (url: URL | HTMLAnchorElement | Location = location): boolean => // Static code, not the editor


### PR DESCRIPTION
- Include `isSingleGist` in `hasRichTextEditor`

example URL:
- https://gist.github.com/KennethTsang9286/63744c422e267fd9f4c4b94ec8a179f6
