### PR TITLE
Fix `canUserEditRepo`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -487,7 +487,7 @@ collect.set('isRepositoryActions', [
 
 export const canUserEditOrganization = (): boolean => isOrganizationProfile() && exists('.pagehead-tabs-item[href$="/settings/profile"]');
 
-export const canUserEditRepo = (): boolean => isRepo() && exists('.reponav-item[href$="/settings"], [data-tab-item="settings-tab"]');
+export const canUserEditRepo = (): boolean => isRepo() && exists('.reponav-item[href$="/settings"], [data-tab-item$="settings-tab"]');
 
 export const isNewRepo = (url: URL | HTMLAnchorElement | Location = location): boolean => url.pathname === '/new';
 collect.set('isNewRepo', [


### PR DESCRIPTION
This PR fixes `canUserEditRepo` so it can be used in https://github.com/sindresorhus/refined-github/pull/3783.

See https://github.com/sindresorhus/refined-github/pull/3840#issue-545224656 for the explanation behind this change.