### PR TITLE
Add `isNewWikiPage` and `isEditingWikiPage`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -267,7 +267,7 @@ collect.set('isEditingRelease', [
 	'https://github.com/sindresorhus/refined-github/releases/edit/v1.2.3',
 ]);
 
-export const isEditingWiki = (url: URL | HTMLAnchorElement | Location = location): boolean => isRepoWiki() && /\/_(edit|new)$/.test(url);
+export const isEditingWiki = (url: URL | HTMLAnchorElement | Location = location): boolean => isRepoWiki() && /\/_(edit|new)$/.test(url.href);
 collect.set('isEditingWiki', [
 	'https://github.com/tooomm/wikitest/wiki/_new',
 	'https://github.com/tooomm/wikitest/wiki/Getting-Started/_edit',

--- a/index.ts
+++ b/index.ts
@@ -267,6 +267,12 @@ collect.set('isEditingRelease', [
 	'https://github.com/sindresorhus/refined-github/releases/edit/v1.2.3',
 ]);
 
+export const isEditingWiki = (url: URL | HTMLAnchorElement | Location = location): boolean => isRepoWiki() && /\/_(edit|new)$/.test(url);
+collect.set('isEditingWiki', [
+	'https://github.com/tooomm/wikitest/wiki/_new',
+	'https://github.com/tooomm/wikitest/wiki/Getting-Started/_edit',
+]);
+
 export const isRepo = (url: URL | HTMLAnchorElement | Location = location): boolean => /^[^/]+\/[^/]+/.test(getCleanPathname(url)) &&
 	!reservedNames.includes(url.pathname.split('/', 2)[1]!) &&
 	!isDashboard(url) &&

--- a/index.ts
+++ b/index.ts
@@ -419,6 +419,8 @@ collect.set('isRepoTree', [
 export const isRepoWiki = (url: URL | HTMLAnchorElement | Location = location): boolean => Boolean(getRepo(url)?.path.startsWith('wiki'));
 collect.set('isRepoWiki', [
 	'https://github.com/lukesampson/scoop/wiki',
+	'https://github.com/tooomm/wikitest/wiki/_new',
+	'https://github.com/tooomm/wikitest/wiki/Getting-Started/_edit',
 ]);
 
 export const isSingleCommit = (url: URL | HTMLAnchorElement | Location = location): boolean => /^commit\/[\da-f]{5,40}/.test(getRepo(url)?.path!);

--- a/index.ts
+++ b/index.ts
@@ -267,7 +267,7 @@ collect.set('isEditingRelease', [
 	'https://github.com/sindresorhus/refined-github/releases/edit/v1.2.3',
 ]);
 
-export const isEditingWiki = (url: URL | HTMLAnchorElement | Location = location): boolean => isRepoWiki() && /\/_(edit|new)$/.test(url.href);
+export const isEditingWiki = (url: URL | HTMLAnchorElement | Location = location): boolean => isRepoWiki(url) && /\/_(edit|new)$/.test(url.href);
 collect.set('isEditingWiki', [
 	'https://github.com/tooomm/wikitest/wiki/_new',
 	'https://github.com/tooomm/wikitest/wiki/Getting-Started/_edit',

--- a/index.ts
+++ b/index.ts
@@ -151,7 +151,7 @@ collect.set('isNewRelease', [
 	'https://github.com/sindresorhus/refined-github/releases/new',
 ]);
 
-export const isNewWikiPage = (url: URL | HTMLAnchorElement | Location = location): boolean => isRepoWiki(url) && url.href.endsWith('/_new');
+export const isNewWikiPage = (url: URL | HTMLAnchorElement | Location = location): boolean => isRepoWiki(url) && getCleanPathname(url).endsWith('/_new');
 collect.set('isNewWikiPage', [
 	'https://github.com/tooomm/wikitest/wiki/_new',
 ]);
@@ -272,7 +272,7 @@ collect.set('isEditingRelease', [
 	'https://github.com/sindresorhus/refined-github/releases/edit/v1.2.3',
 ]);
 
-export const isEditingWikiPage = (url: URL | HTMLAnchorElement | Location = location): boolean => isRepoWiki(url) && url.href.endsWith('/_edit');
+export const isEditingWikiPage = (url: URL | HTMLAnchorElement | Location = location): boolean => isRepoWiki(url) && getCleanPathname(url).endsWith('/_edit');
 collect.set('isEditingWikiPage', [
 	'https://github.com/tooomm/wikitest/wiki/Getting-Started/_edit',
 ]);

--- a/index.ts
+++ b/index.ts
@@ -151,6 +151,11 @@ collect.set('isNewRelease', [
 	'https://github.com/sindresorhus/refined-github/releases/new',
 ]);
 
+export const isNewWikiPage = (url: URL | HTMLAnchorElement | Location = location): boolean => isRepoWiki(url) && url.href.endsWith('/_new');
+collect.set('isNewWikiPage', [
+	'https://github.com/tooomm/wikitest/wiki/_new',
+]);
+
 export const isNotifications = (url: URL | HTMLAnchorElement | Location = location): boolean => getCleanPathname(url) === 'notifications';
 collect.set('isNotifications', [
 	'https://github.com/notifications',
@@ -267,9 +272,8 @@ collect.set('isEditingRelease', [
 	'https://github.com/sindresorhus/refined-github/releases/edit/v1.2.3',
 ]);
 
-export const isEditingWiki = (url: URL | HTMLAnchorElement | Location = location): boolean => isRepoWiki(url) && /\/_(edit|new)$/.test(url.href);
-collect.set('isEditingWiki', [
-	'https://github.com/tooomm/wikitest/wiki/_new',
+export const isEditingWikiPage = (url: URL | HTMLAnchorElement | Location = location): boolean => isRepoWiki(url) && url.href.endsWith('/_edit');
+collect.set('isEditingWikiPage', [
 	'https://github.com/tooomm/wikitest/wiki/Getting-Started/_edit',
 ]);
 


### PR DESCRIPTION
This can be used in sindresorhus/refined-github#4463 and sindresorhus/refined-github#4467.

Very interestingly, it seems you can actually create a page named `_new` or `_edit`, but you can't view it (only edit), so this should be safe.