### PR TITLE
Use faster detections for user profiles

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -474,7 +474,7 @@ collect.set('isBranches', [
 	'https://github.com/sindresorhus/refined-github/branches',
 ]);
 
-export const isUserProfile = (): boolean => exists('.user-profile-nav');
+export const isUserProfile = (): boolean => exists('meta[property="og:type"][content="profile"]') && !isOrganizationProfile();
 
 export const isUserProfileMainTab = (): boolean => exists('[aria-label="User profile"] > .selected:first-child');
 

--- a/index.ts
+++ b/index.ts
@@ -483,27 +483,56 @@ collect.set('isProfile', [
 	'https://github.com/fregante',
 	'https://github.com/github',
 	'https://github.com/babel',
+	'https://github.com/fregante?tab=repositories',
+	'https://github.com/fregante?tab=repositories&type=source',
+	'https://github.com/fregante?tab=repositories&q=&type=source&language=css&sort=',
+	'https://github.com/fregante?tab=stars',
+	'https://github.com/fregante?direction=desc&sort=updated&tab=stars',
+	'https://github.com/fregante?tab=followers',
+	'https://github.com/sindresorhus?tab=followers',
+	'https://github.com/fregante?tab=following',
+	'https://github.com/sindresorhus?tab=following',
 ]);
 
 export const isUserProfile = (): boolean => isProfile() && !isOrganizationProfile();
 
-export const isUserProfileMainTab = (): boolean => exists('[aria-label="User profile"] > .selected:first-child');
-
-export const isUserProfileRepoTab = (): boolean =>
+export const isUserProfileMainTab = (): boolean =>
 	isUserProfile()
-	&& new URLSearchParams(location.search).get('tab') === 'repositories';
+	&& !new URLSearchParams(location.search).has('tab');
 
-export const isUserProfileStarsTab = (): boolean =>
-	isUserProfile()
-	&& new URLSearchParams(location.search).get('tab') === 'stars';
+// The following can be URL-based because they have a `tab` parameter, unlike the organizations
+export const isUserProfileRepoTab = (url: URL | HTMLAnchorElement | Location = location): boolean =>
+	isProfile(url)
+	&& new URLSearchParams(url.search).get('tab') === 'repositories';
+collect.set('isUserProfileRepoTab', [
+	'https://github.com/fregante?tab=repositories',
+	'https://github.com/fregante?tab=repositories&type=source',
+	'https://github.com/fregante?tab=repositories&q=&type=source&language=css&sort=',
+]);
 
-export const isUserProfileFollowersTab = (): boolean =>
-	isUserProfile()
-	&& new URLSearchParams(location.search).get('tab') === 'followers';
+export const isUserProfileStarsTab = (url: URL | HTMLAnchorElement | Location = location): boolean =>
+	isProfile(url)
+	&& new URLSearchParams(url.search).get('tab') === 'stars';
+collect.set('isUserProfileStarsTab', [
+	'https://github.com/fregante?tab=stars',
+	'https://github.com/fregante?direction=desc&sort=updated&tab=stars',
+]);
 
-export const isUserProfileFollowingTab = (): boolean =>
-	isUserProfile()
-	&& new URLSearchParams(location.search).get('tab') === 'following';
+export const isUserProfileFollowersTab = (url: URL | HTMLAnchorElement | Location = location): boolean =>
+	isProfile(url)
+	&& new URLSearchParams(url.search).get('tab') === 'followers';
+collect.set('isUserProfileFollowersTab', [
+	'https://github.com/fregante?tab=followers',
+	'https://github.com/sindresorhus?tab=followers',
+]);
+
+export const isUserProfileFollowingTab = (url: URL | HTMLAnchorElement | Location = location): boolean =>
+	isProfile(url)
+	&& new URLSearchParams(url.search).get('tab') === 'following';
+collect.set('isUserProfileFollowingTab', [
+	'https://github.com/fregante?tab=following',
+	'https://github.com/sindresorhus?tab=following',
+]);
 
 export const isSingleTag = (url: URL | HTMLAnchorElement | Location = location): boolean => /^(releases\/tag)/.test(getRepo(url)?.path!);
 collect.set('isSingleTag', [

--- a/index.ts
+++ b/index.ts
@@ -474,7 +474,18 @@ collect.set('isBranches', [
 	'https://github.com/sindresorhus/refined-github/branches',
 ]);
 
-export const isUserProfile = (): boolean => exists('meta[property="og:type"][content="profile"]') && !isOrganizationProfile();
+export const isProfile = (url: URL | HTMLAnchorElement | Location = location): boolean => {
+	const pathname = getCleanPathname(url);
+	return pathname.length > 0 && !pathname.includes('/') && !reservedNames.includes(pathname);
+};
+
+collect.set('isProfile', [
+	'https://github.com/fregante',
+	'https://github.com/github',
+	'https://github.com/babel',
+]);
+
+export const isUserProfile = (): boolean => isProfile() && !isOrganizationProfile();
 
 export const isUserProfileMainTab = (): boolean => exists('[aria-label="User profile"] > .selected:first-child');
 


### PR DESCRIPTION
Context: https://github.com/sindresorhus/refined-github/issues/4472

Possible improvements:

- [x] #95, which just checks `github-reserved-names` against a no-slash URL  
- [ ] Find better meta tag without having to use `!isOrganizationProfile()`
- [x] Ensure it works on all tabs and never includes the org profile

Possible "better meta tag" ideas

- twitter:title has `- overview` in the user, but it doesn't sound super safe

	<img width="292" alt="Screen Shot 12" src="https://user-images.githubusercontent.com/1402241/122446634-15727500-cfcd-11eb-9c96-caea9ff1f011.png">
	
	<img width="379" alt="Screen Shot 10" src="https://user-images.githubusercontent.com/1402241/122446513-f378f280-cfcc-11eb-9168-d9871267c046.png">


- analytics-location sounds great

	<img width="514" alt="Screen Shot 13" src="https://user-images.githubusercontent.com/1402241/122447070-8f0a6300-cfcd-11eb-8dbc-2dd7757dcbf7.png">
	
	<img width="520" alt="Screen Shot 14" src="https://user-images.githubusercontent.com/1402241/122447005-7ac66600-cfcd-11eb-92cc-ff100bcdfa0e.png">
