### PR TITLE
Add organization-specific detections

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -172,29 +172,32 @@ collect.set('isOrganizationRepoList', [
 export const isOrganizationRepo = (): boolean => Boolean(document.querySelector<HTMLElement>('[data-owner-scoped-search-url]')?.dataset['ownerScopedSearchUrl']!.startsWith('/org'));
 
 export const isOrganizationPackageList = (url: URL | HTMLAnchorElement | Location = location): boolean => /^orgs\/[^/]+\/packages$/.test(getCleanPathname(url));
-collect.set('isOrganizationPackagesList', [
+collect.set('isOrganizationPackageList', [
 	'https://github.com/orgs/github/packages',
+	'https://github.com/orgs/microsoft/packages',
+	'https://github.com/orgs/npm/packages',
 ]);
 
 export const isOrganizationMembers = (url: URL | HTMLAnchorElement | Location = location): boolean => /^orgs\/[^/]+\/people$/.test(getCleanPathname(url));
-collect.set('isOrganizationPeopleList', [
+collect.set('isOrganizationMembers', [
 	'https://github.com/orgs/github/people',
 	'https://github.com/orgs/github/people?page=2',
 ]);
 
-export const isOrganizationProjectsList = (url: URL | HTMLAnchorElement | Location = location): boolean => /^orgs\/[^/]+\/projects$/.test(getCleanPathname(url));
-collect.set('isOrganizationProjectsList', [
+export const isOrganizationProjectList = (url: URL | HTMLAnchorElement | Location = location): boolean => /^orgs\/[^/]+\/projects$/.test(getCleanPathname(url));
+collect.set('isOrganizationProjectList', [
 	'https://github.com/orgs/github/projects',
+	'https://github.com/orgs/cncf/projects',
+	'https://github.com/orgs/microsoft/projects',
+	'https://github.com/orgs/python/projects?query=is%3Aclosed',
+	'https://github.com/orgs/npm/projects?query=is%3Aclosed',
 ]);
 
 export const isOrganizationProject = (url: URL | HTMLAnchorElement | Location = location): boolean => /^orgs\/[^/]+\/projects\/[^/]+$/.test(getCleanPathname(url));
 collect.set('isOrganizationProject', [
 	'https://github.com/orgs/cncf/projects/1',
-]);
-
-export const isOrganizationDiscussionsList = (url: URL | HTMLAnchorElement | Location = location): boolean => /^orgs\/[^/]+\/discussions$/.test(getCleanPathname(url));
-collect.set('isOrganizationDiscussionsList', [
-	'https://github.com/orgs/github/discussions',
+	'https://github.com/orgs/python/projects/1'
+	'https://github.com/orgs/microsoft/projects/30',
 ]);
 
 export const isOrganizationTeamDiscussion = (url: URL | HTMLAnchorElement | Location = location): boolean => /^orgs\/[^/]+\/teams\/[^/]+($|\/discussions)/.test(getCleanPathname(url));
@@ -203,8 +206,14 @@ collect.set('isOrganizationTeamDiscussion', [
 	'https://github.com/orgs/refined-github/teams/core-team/discussions/1',
 	'https://github.com/orgs/refined-github/teams/core-team',
 ]);
+
 /** @deprecated use isOrganizationTeamDiscussion instead */
 export const isOrganizationDiscussion = isOrganizationTeamDiscussion;
+collect.set('isOrganizationDiscussion', [
+	'https://github.com/orgs/refined-github/teams/core-team/discussions?pinned=1',
+	'https://github.com/orgs/refined-github/teams/core-team/discussions/1',
+	'https://github.com/orgs/refined-github/teams/core-team',
+]);
 
 export const isOwnUserProfile = (): boolean => getCleanPathname() === getUsername();
 

--- a/index.ts
+++ b/index.ts
@@ -163,7 +163,39 @@ collect.set('isNotifications', [
 
 export const isOrganizationProfile = (): boolean => exists('meta[name="hovercard-subject-tag"][content^="organization"]');
 
+export const isOrganizationRepoList = (url: URL | HTMLAnchorElement | Location = location): boolean => /^orgs\/[^/]+\/repositories$/.test(getCleanPathname(url));
+collect.set('isOrganizationRepoList', [
+	'https://github.com/orgs/github/repositories',
+	'https://github.com/orgs/github/repositories?page=2',
+]);
+
 export const isOrganizationRepo = (): boolean => Boolean(document.querySelector<HTMLElement>('[data-owner-scoped-search-url]')?.dataset['ownerScopedSearchUrl']!.startsWith('/org'));
+
+export const isOrganizationPackagesList = (url: URL | HTMLAnchorElement | Location = location): boolean => /^orgs\/[^/]+\/packages$/.test(getCleanPathname(url));
+collect.set('isOrganizationPackagesList', [
+	'https://github.com/orgs/github/packages',
+]);
+
+export const isOrganizationPeopleList = (url: URL | HTMLAnchorElement | Location = location): boolean => /^orgs\/[^/]+\/people$/.test(getCleanPathname(url));
+collect.set('isOrganizationPeopleList', [
+	'https://github.com/orgs/github/people',
+	'https://github.com/orgs/github/people?page=2',
+]);
+
+export const isOrganizationProjectsList = (url: URL | HTMLAnchorElement | Location = location): boolean => /^orgs\/[^/]+\/projects$/.test(getCleanPathname(url));
+collect.set('isOrganizationProjectsList', [
+	'https://github.com/orgs/github/projects',
+]);
+
+export const isOrganizationProject = (url: URL | HTMLAnchorElement | Location = location): boolean => /^orgs\/[^/]+\/projects\/[^/]+$/.test(getCleanPathname(url));
+collect.set('isOrganizationProject', [
+	'https://github.com/orgs/cncf/projects/1',
+]);
+
+export const isOrganizationDiscussionsList = (url: URL | HTMLAnchorElement | Location = location): boolean => /^orgs\/[^/]+\/discussions$/.test(getCleanPathname(url));
+collect.set('isOrganizationDiscussionsList', [
+	'https://github.com/orgs/github/discussions',
+]);
 
 export const isOrganizationDiscussion = (url: URL | HTMLAnchorElement | Location = location): boolean => /^orgs\/[^/]+\/teams\/[^/]+($|\/discussions)/.test(getCleanPathname(url));
 collect.set('isOrganizationDiscussion', [

--- a/index.ts
+++ b/index.ts
@@ -197,12 +197,14 @@ collect.set('isOrganizationDiscussionsList', [
 	'https://github.com/orgs/github/discussions',
 ]);
 
-export const isOrganizationDiscussion = (url: URL | HTMLAnchorElement | Location = location): boolean => /^orgs\/[^/]+\/teams\/[^/]+($|\/discussions)/.test(getCleanPathname(url));
-collect.set('isOrganizationDiscussion', [
+export const isOrganizationTeamDiscussion = (url: URL | HTMLAnchorElement | Location = location): boolean => /^orgs\/[^/]+\/teams\/[^/]+($|\/discussions)/.test(getCleanPathname(url));
+collect.set('isOrganizationTeamDiscussion', [
 	'https://github.com/orgs/refined-github/teams/core-team/discussions?pinned=1',
 	'https://github.com/orgs/refined-github/teams/core-team/discussions/1',
 	'https://github.com/orgs/refined-github/teams/core-team',
 ]);
+/** @deprecated use isOrganizationTeamDiscussion instead */
+export const isOrganizationDiscussion = isOrganizationTeamDiscussion;
 
 export const isOwnUserProfile = (): boolean => getCleanPathname() === getUsername();
 

--- a/index.ts
+++ b/index.ts
@@ -171,12 +171,12 @@ collect.set('isOrganizationRepoList', [
 
 export const isOrganizationRepo = (): boolean => Boolean(document.querySelector<HTMLElement>('[data-owner-scoped-search-url]')?.dataset['ownerScopedSearchUrl']!.startsWith('/org'));
 
-export const isOrganizationPackagesList = (url: URL | HTMLAnchorElement | Location = location): boolean => /^orgs\/[^/]+\/packages$/.test(getCleanPathname(url));
+export const isOrganizationPackageList = (url: URL | HTMLAnchorElement | Location = location): boolean => /^orgs\/[^/]+\/packages$/.test(getCleanPathname(url));
 collect.set('isOrganizationPackagesList', [
 	'https://github.com/orgs/github/packages',
 ]);
 
-export const isOrganizationPeopleList = (url: URL | HTMLAnchorElement | Location = location): boolean => /^orgs\/[^/]+\/people$/.test(getCleanPathname(url));
+export const isOrganizationMembers = (url: URL | HTMLAnchorElement | Location = location): boolean => /^orgs\/[^/]+\/people$/.test(getCleanPathname(url));
 collect.set('isOrganizationPeopleList', [
 	'https://github.com/orgs/github/people',
 	'https://github.com/orgs/github/people?page=2',


### PR DESCRIPTION
GitHub refreshed organization profiles and put up more organization-wide tabs on the organization profile with dedicated routes to each of the tabs ( unlike user profiles ).

This change-set also renames `isOrganizationDiscussion` to `isOrganizationTeamDiscussion` since 'discussions' are now a core public feature and not only restricted to organization teams. And moreover, the organization team discussions are kind of disjoint from the public feature.

There are 2 other detections that would depend on `isOrganizationRepo`. I was not sure whether to include them.
- `isOrganizationPackage`
- `isOrganizationDiscussion`

Both of these detections eventually redirect into a organization repository.

Organization packages do have a URL in the `/orgs` namespace, but since they are eventually redirected to an organization repository, I am not sure whether it is worth 'detecting'. Maybe, it might be a dedicated page in the future? :thinking: 
