### PR TITLE
Add `hasFooEditor`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -292,8 +292,14 @@ collect.set('isDeletingFile', [
 	'https://github.com/sindresorhus/refined-github/delete/ghe-injection/source/background.ts',
 ]);
 
-export const isEditingFile = (url: URL | HTMLAnchorElement | Location = location): boolean => isNewFile(url) || isDeletingFile(url) || Boolean(getRepo(url)?.path.startsWith('edit'));
+export const isEditingFile = (url: URL | HTMLAnchorElement | Location = location): boolean => Boolean(getRepo(url)?.path.startsWith('edit'));
 collect.set('isEditingFile', [
+	'https://github.com/sindresorhus/refined-github/edit/master/readme.md',
+	'https://github.com/sindresorhus/refined-github/edit/ghe-injection/source/background.ts',
+]);
+
+export const hasFileEditor = (url: URL | HTMLAnchorElement | Location = location): boolean => isEditingFile(url) || isNewFile(url) || isDeletingFile(url);
+collect.set('hasFileEditor', [
 	'https://github.com/sindresorhus/refined-github/new/main',
 	'https://github.com/sindresorhus/refined-github/delete/master/readme.md',
 	'https://github.com/sindresorhus/refined-github/delete/ghe-injection/source/background.ts',

--- a/index.ts
+++ b/index.ts
@@ -299,13 +299,7 @@ collect.set('isEditingFile', [
 ]);
 
 export const hasFileEditor = (url: URL | HTMLAnchorElement | Location = location): boolean => isEditingFile(url) || isNewFile(url) || isDeletingFile(url);
-collect.set('hasFileEditor', [
-	'https://github.com/sindresorhus/refined-github/new/main',
-	'https://github.com/sindresorhus/refined-github/delete/master/readme.md',
-	'https://github.com/sindresorhus/refined-github/delete/ghe-injection/source/background.ts',
-	'https://github.com/sindresorhus/refined-github/edit/master/readme.md',
-	'https://github.com/sindresorhus/refined-github/edit/ghe-injection/source/background.ts',
-]);
+collect.set('hasFileEditor', combinedTestOnly);
 
 export const isEditingRelease = (url: URL | HTMLAnchorElement | Location = location): boolean => Boolean(getRepo(url)?.path.startsWith('releases/edit'));
 collect.set('isEditingRelease', [
@@ -313,10 +307,7 @@ collect.set('isEditingRelease', [
 ]);
 
 export const hasReleaseEditor = (url: URL | HTMLAnchorElement | Location = location): boolean => isEditingRelease(url) || isNewRelease(url);
-collect.set('hasReleaseEditor', [
-	'https://github.com/sindresorhus/refined-github/releases/new',
-	'https://github.com/sindresorhus/refined-github/releases/edit/v1.2.3',
-]);
+collect.set('hasReleaseEditor', combinedTestOnly);
 
 export const isEditingWikiPage = (url: URL | HTMLAnchorElement | Location = location): boolean => isRepoWiki(url) && getCleanPathname(url).endsWith('/_edit');
 collect.set('isEditingWikiPage', [
@@ -324,10 +315,7 @@ collect.set('isEditingWikiPage', [
 ]);
 
 export const hasWikiPageEditor = (url: URL | HTMLAnchorElement | Location = location): boolean => isEditingWikiPage(url) || isNewWikiPage(url);
-collect.set('hasWikiPageEditor', [
-	'https://github.com/tooomm/wikitest/wiki/_new',
-	'https://github.com/tooomm/wikitest/wiki/Getting-Started/_edit',
-]);
+collect.set('hasWikiPageEditor', combinedTestOnly);
 
 export const isRepo = (url: URL | HTMLAnchorElement | Location = location): boolean => /^[^/]+\/[^/]+/.test(getCleanPathname(url))
 	&& !reservedNames.includes(url.pathname.split('/', 2)[1]!)

--- a/index.ts
+++ b/index.ts
@@ -292,14 +292,16 @@ collect.set('isDeletingFile', [
 	'https://github.com/sindresorhus/refined-github/delete/ghe-injection/source/background.ts',
 ]);
 
-export const isEditingFile = (url: URL | HTMLAnchorElement | Location = location): boolean => Boolean(getRepo(url)?.path.startsWith('edit'));
+export const isEditingFile = (url: URL | HTMLAnchorElement | Location = location): boolean => isNewFile(url) || Boolean(getRepo(url)?.path.startsWith('edit'));
 collect.set('isEditingFile', [
+	'https://github.com/sindresorhus/refined-github/new/main',
 	'https://github.com/sindresorhus/refined-github/edit/master/readme.md',
 	'https://github.com/sindresorhus/refined-github/edit/ghe-injection/source/background.ts',
 ]);
 
-export const isEditingRelease = (url: URL | HTMLAnchorElement | Location = location): boolean => Boolean(getRepo(url)?.path.startsWith('releases/edit'));
+export const isEditingRelease = (url: URL | HTMLAnchorElement | Location = location): boolean => isNewRelease(url) || Boolean(getRepo(url)?.path.startsWith('releases/edit'));
 collect.set('isEditingRelease', [
+	'https://github.com/sindresorhus/refined-github/releases/new',
 	'https://github.com/sindresorhus/refined-github/releases/edit/v1.2.3',
 ]);
 
@@ -580,7 +582,7 @@ export const hasRichTextEditor = (url: URL | HTMLAnchorElement | Location = loca
 	|| isNewIssue(url)
 	|| isCompare(url)
 	|| isRepliesSettings(url)
-	|| isNewRelease(url)
+	|| isEditingRelease(url)
 	|| isDiscussion(url);
 
 collect.set('hasCode', combinedTestOnly);

--- a/index.ts
+++ b/index.ts
@@ -307,14 +307,24 @@ collect.set('hasFileEditor', [
 	'https://github.com/sindresorhus/refined-github/edit/ghe-injection/source/background.ts',
 ]);
 
-export const isEditingRelease = (url: URL | HTMLAnchorElement | Location = location): boolean => isNewRelease(url) || Boolean(getRepo(url)?.path.startsWith('releases/edit'));
+export const isEditingRelease = (url: URL | HTMLAnchorElement | Location = location): boolean => Boolean(getRepo(url)?.path.startsWith('releases/edit'));
 collect.set('isEditingRelease', [
+	'https://github.com/sindresorhus/refined-github/releases/edit/v1.2.3',
+]);
+
+export const hasReleaseEditor = (url: URL | HTMLAnchorElement | Location = location): boolean => isEditingRelease(url) || isNewRelease(url);
+collect.set('hasReleaseEditor', [
 	'https://github.com/sindresorhus/refined-github/releases/new',
 	'https://github.com/sindresorhus/refined-github/releases/edit/v1.2.3',
 ]);
 
-export const isEditingWikiPage = (url: URL | HTMLAnchorElement | Location = location): boolean => isNewWikiPage(url) || (isRepoWiki(url) && getCleanPathname(url).endsWith('/_edit'));
+export const isEditingWikiPage = (url: URL | HTMLAnchorElement | Location = location): boolean => isRepoWiki(url) && getCleanPathname(url).endsWith('/_edit');
 collect.set('isEditingWikiPage', [
+	'https://github.com/tooomm/wikitest/wiki/Getting-Started/_edit',
+]);
+
+export const hasWikiPageEditor = (url: URL | HTMLAnchorElement | Location = location): boolean => isEditingWikiPage(url) || isNewWikiPage(url);
+collect.set('hasWikiPageEditor', [
 	'https://github.com/tooomm/wikitest/wiki/_new',
 	'https://github.com/tooomm/wikitest/wiki/Getting-Started/_edit',
 ]);

--- a/index.ts
+++ b/index.ts
@@ -305,8 +305,9 @@ collect.set('isEditingRelease', [
 	'https://github.com/sindresorhus/refined-github/releases/edit/v1.2.3',
 ]);
 
-export const isEditingWikiPage = (url: URL | HTMLAnchorElement | Location = location): boolean => isRepoWiki(url) && getCleanPathname(url).endsWith('/_edit');
+export const isEditingWikiPage = (url: URL | HTMLAnchorElement | Location = location): boolean => isNewWikiPage(url) || (isRepoWiki(url) && getCleanPathname(url).endsWith('/_edit'));
 collect.set('isEditingWikiPage', [
+	'https://github.com/tooomm/wikitest/wiki/_new'
 	'https://github.com/tooomm/wikitest/wiki/Getting-Started/_edit',
 ]);
 

--- a/index.ts
+++ b/index.ts
@@ -295,6 +295,8 @@ collect.set('isDeletingFile', [
 export const isEditingFile = (url: URL | HTMLAnchorElement | Location = location): boolean => isNewFile(url) || isDeletingFile(url) || Boolean(getRepo(url)?.path.startsWith('edit'));
 collect.set('isEditingFile', [
 	'https://github.com/sindresorhus/refined-github/new/main',
+	'https://github.com/sindresorhus/refined-github/delete/master/readme.md',
+	'https://github.com/sindresorhus/refined-github/delete/ghe-injection/source/background.ts',
 	'https://github.com/sindresorhus/refined-github/edit/master/readme.md',
 	'https://github.com/sindresorhus/refined-github/edit/ghe-injection/source/background.ts',
 ]);

--- a/index.ts
+++ b/index.ts
@@ -601,7 +601,7 @@ export const hasRichTextEditor = (url: URL | HTMLAnchorElement | Location = loca
 	|| isNewIssue(url)
 	|| isCompare(url)
 	|| isRepliesSettings(url)
-	|| isEditingRelease(url)
+	|| hasReleaseEditor(url)
 	|| isDiscussion(url);
 
 collect.set('hasCode', combinedTestOnly);

--- a/index.ts
+++ b/index.ts
@@ -292,7 +292,7 @@ collect.set('isDeletingFile', [
 	'https://github.com/sindresorhus/refined-github/delete/ghe-injection/source/background.ts',
 ]);
 
-export const isEditingFile = (url: URL | HTMLAnchorElement | Location = location): boolean => isNewFile(url) || Boolean(getRepo(url)?.path.startsWith('edit'));
+export const isEditingFile = (url: URL | HTMLAnchorElement | Location = location): boolean => isNewFile(url) || isDeletingFile(url) || Boolean(getRepo(url)?.path.startsWith('edit'));
 collect.set('isEditingFile', [
 	'https://github.com/sindresorhus/refined-github/new/main',
 	'https://github.com/sindresorhus/refined-github/edit/master/readme.md',

--- a/index.ts
+++ b/index.ts
@@ -307,7 +307,7 @@ collect.set('isEditingRelease', [
 
 export const isEditingWikiPage = (url: URL | HTMLAnchorElement | Location = location): boolean => isNewWikiPage(url) || (isRepoWiki(url) && getCleanPathname(url).endsWith('/_edit'));
 collect.set('isEditingWikiPage', [
-	'https://github.com/tooomm/wikitest/wiki/_new'
+	'https://github.com/tooomm/wikitest/wiki/_new',
 	'https://github.com/tooomm/wikitest/wiki/Getting-Started/_edit',
 ]);
 


### PR DESCRIPTION
Reason: both kind of pages are almost identical ("editing something").

While both are frequently used together, sometimes `isNewFoo` is easily left out since it's a special case that doesn't matter most of the time.

~~To replicate the old behavior of `isEditingFoo`, use `isEditingFoo() && !isNewFoo()`.~~

We need some utils to check for these pages at the same time.

Changes:

- Add `hasFileEditor`: `isEditingFile`, `isNewFile` and `isDeletingFile`
- Add `hasReleaseEditor`: `isEditingRelease` and `isNewRelease`
- Add `hasWikiPageEditor`: `isEditingWikiPage` and `isNewWikiPage`
- `hasRichTextEditor` checks for `hasReleaseEditor` instead of `isEditingRelease`