### PR TITLE
Add `hasFiles`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -601,6 +601,12 @@ export const hasCode = (url: URL | HTMLAnchorElement | Location = location): boo
 	|| isCompare(url)
 	|| isBlame(url);
 
+collect.set('hasFiles', combinedTestOnly);
+export const hasFiles = (url: URL | HTMLAnchorElement | Location = location): boolean => // Has a list of files
+	isCommit(url)
+	|| isCompare(url)
+	|| isPRFiles(url);
+
 export const isMarketplaceAction = (url: URL | HTMLAnchorElement | Location = location): boolean => url.pathname.startsWith('/marketplace/actions/');
 collect.set('isMarketplaceAction', [
 	'https://github.com/marketplace/actions/urlchecker-action',


### PR DESCRIPTION
The combination of `isCommit`, `isCompare` and `isPRFiles` is used a lot in Refined GitHub (for example, [`easy-toggle-files`](https://github.com/refined-github/refined-github/blob/c9d133547f45321c28fb7ddb35ffc08189c9082e/source/features/easy-toggle-files.tsx#L23-L25) and [`more-file-links`](https://github.com/refined-github/refined-github/blob/c9d133547f45321c28fb7ddb35ffc08189c9082e/source/features/more-file-links.tsx#L37-L39)). Adding them as a group so it remembers which pages have a list of files for us.